### PR TITLE
create submodules from HEAD

### DIFF
--- a/lib/grit/ref.rb
+++ b/lib/grit/ref.rb
@@ -69,7 +69,7 @@ module Grit
     def self.current(repo, options = {})
       begin
         head_ref = repo.git.symbolic_ref({:q => true}, 'HEAD').chomp
-      rescue Git::Errors::CommandFailed => err
+      rescue Grit::Errors::CommandFailed => err
         raise  if err.exitstatus != 1
         return nil
       end

--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -68,8 +68,12 @@ module Grit
       @working_dir = File.dirname(git_path) if !@bare
 
       @git = Git.new(@path)
-      @submodules = Grit::Submodule.create_submodules(self)
+      
+      create_submodules(@git.rev_parse({}, 'HEAD'))
+    end
 
+    def create_submodules(head = 'master')
+      @submodules = Grit::Submodule.create_submodules(self, head)
     end
 
     # Public: Initialize a git repository (create it on the filesystem). By

--- a/lib/grit/submodule.rb
+++ b/lib/grit/submodule.rb
@@ -63,7 +63,7 @@ module Grit
 
     # Entry point for other commands
     def self.submodule(parent, cmd, options={}, *args)
-      parent.git.submodule(cmd, opts, *args)
+      parent.git.submodule(cmd, options, *args)
     end
 
     def self.add(parent, url, path='')


### PR DESCRIPTION
Fixes this:

  git clone &lt;URL&gt; &lt;PATH&gt;
  git checkout &lt;SHA&gt;

  repo = Grit::Repo.new("&lt;PATH&gt;")
  repo.submodules # parses .gitmodules from "master" instead of HEAD.
